### PR TITLE
Move and update deployment scripts

### DIFF
--- a/build/deploy-debug.ps1
+++ b/build/deploy-debug.ps1
@@ -1,12 +1,12 @@
 ﻿param (
-    [string]$WorkingDir = ".", 
+    [string]$ProjectDir = ".", 
     [string]$ProfileName = $(throw "ProfileName is required."),
     [string]$ModName = $(throw "ModName is required.")
 )
 
 $ErrorActionPreference = "Stop"
 
-$inputDir = Join-Path $WorkingDir "bin\Debug\netstandard2.0"
+$inputDir = Join-Path $ProjectDir "bin\Debug\netstandard2.1"
 $outputDir = $Env:appdata + "\r2modmanPlus-local\RiskOfRain2\profiles\"+$ProfileName+"\BepInEx\plugins\"+$ModName
 
 if (!(Test-Path $outputDir)) {
@@ -22,6 +22,28 @@ foreach ($pdb in $pdbs)
 {
     $dll = $pdb.Basename + ".dll"
     & $mono ".\pdb2mdb.exe" $outputDir\$dll
+}
+
+foreach ($item in Get-ChildItem -Path $outputDir)
+{
+    if (Test-Path (Join-Path "D:\Program Files (x86)\Steam\steamapps\common\Risk of Rain 2\Risk of Rain 2_Data\Managed" $item.Name))
+    {
+        Write-Output "$($item.Name) exists in RoR2 install directory"
+    }
+    elseif ($item.Name -match "^System\..*\.dll$")
+    {
+        Write-Output "$item.Name is a System library"
+    }
+    elseif ($item.Name -match "MMHOOK_RoR2.dll")
+    {
+        Write-Output "$item.Name will be provided by another mod"
+    }
+    else
+    {
+        continue
+    }
+
+    Remove-Item $item.FullName
 }
 
 explorer $outputDir

--- a/build/release.ps1
+++ b/build/release.ps1
@@ -23,7 +23,7 @@ foreach ($File in Get-ChildItem "D:\Program Files (x86)\Steam\steamapps\common\R
     Delete-Files $File.Name
 }
 
-foreach ($Directory in Get-ChildItem .\bin\Release\netstandard2.0 -Directory)
+foreach ($Directory in Get-ChildItem .\bin\Release\netstandard2.1 -Directory)
 {
     Remove-Item $Directory.FullName -Recurse
 }


### PR DESCRIPTION
Modified `deploy-debug.ps1` to use `$ProjectDir` and updated input paths to `netstandard2.1`. Added logic to check for file existence and handle specific cases for system libraries and mod files.

Changed `release.ps1` to delete files from the `netstandard2.1` directory, ensuring proper cleanup operations.